### PR TITLE
Remove write access to user home

### DIFF
--- a/org.gnome.Eolie.json
+++ b/org.gnome.Eolie.json
@@ -14,6 +14,7 @@
     "--env=GST_PLUGIN_PATH_1_0=/app/lib/gstreamer-1.0",
     "--env=SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt",
     "--filesystem=home:ro",
+    "--filesystem=xdg-download",
     "--filesystem=~/.mozilla/firefox:rw",
     "--filesystem=~/.config/chromium:rw",
     "--filesystem=~/.config/chrome:rw",

--- a/org.gnome.Eolie.json
+++ b/org.gnome.Eolie.json
@@ -13,7 +13,7 @@
     "--device=dri",
     "--env=GST_PLUGIN_PATH_1_0=/app/lib/gstreamer-1.0",
     "--env=SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt",
-    "--filesystem=home",
+    "--filesystem=home:ro",
     "--filesystem=~/.mozilla/firefox:rw",
     "--filesystem=~/.config/chromium:rw",
     "--filesystem=~/.config/chrome:rw",


### PR DESCRIPTION
Prevents app from writing on top of arbitrary files in user home which allows arbitrary code execution in host and unlimited crypto ransomware attacks. Fixes #20